### PR TITLE
Add current AGI research resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ by GeorgiaTech The Core of Artificial Intelligence](https://www.udacity.com/cour
 
 * [AGI Society](http://www.agi-society.org/resources/)
 * [Linas Vepstas](https://linas.org/agi.html)
+* [Center for Human-Compatible AI](https://humancompatible.ai/)
+* [Future of Life Institute - Resources](https://futureoflife.org/resource/)
+* [Center for AI Safety](https://www.safe.ai/)
+* [AI Alignment Forum](https://www.alignmentforum.org/)
+* [LessWrong - AI Alignment](https://www.lesswrong.com/tag/ai-alignment)
+* [Epoch AI](https://epoch.ai/)
+* [METR](https://metr.org/)
+* [Redwood Research](https://www.redwoodresearch.org/)
+* [Apollo Research](https://www.apolloresearch.ai/)
+* [FAR.AI](https://far.ai/)
 
 ## Contribute
 


### PR DESCRIPTION
Adds 10 AGI/safety research resources to the More resources section.

I kept this focused on active research groups and forums rather than a broad list of generic AI links. Most links are directly curl-checkable; Alignment Forum and LessWrong block curl with rate limiting, but these are their canonical URLs.

Closes #8